### PR TITLE
Fixing race condition in temporary file naming 

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -33,7 +33,7 @@ requestCounter = 0
 countOfCurrentlyExecutingRequests = 0
 
 createTempFileName = (suffix) ->
-  process.pid + "" + requestCounter + "-" + suffix
+  process.pid + requestCounter + "-" + suffix
 
 createTempFilePath = (prefix) ->
   path.join config.outputDirectory, createTempFileName(prefix)

--- a/server.coffee
+++ b/server.coffee
@@ -40,7 +40,6 @@ createTempFilePath = (prefix) ->
 
 executeThrottled = (req, res) ->
   requestCounter++
-  console.log "tempFileName #{createTempFileName("testing")}"
   # if we've not disabled throttling ( set to -1 ) then we see that we're running no
   # more than our maximum allowed concurrent requests
   if config.maxConcurrentRequests is -1 || (countOfCurrentlyExecutingRequests < config.maxConcurrentRequests)


### PR DESCRIPTION
File names were being created using a request counter, that request
counter was set when a new request was encountered. The function that
created the file names (referencing that request counter) was being
called in the context of callbacks (various) so.... we effectively had a
race condition whereby creation of file names used for different
requests could actually result in the same filename... So in the case of
many concurrent requests forkulator just flat could return the wrong
info... whoops.